### PR TITLE
Add support for winrmcp over WinRM/HTTPS

### DIFF
--- a/winrmcp/endpoint.go
+++ b/winrmcp/endpoint.go
@@ -10,7 +10,7 @@ import (
 	"github.com/masterzen/winrm/winrm"
 )
 
-func parseEndpoint(addr string) (*winrm.Endpoint, error) {
+func parseEndpoint(addr string, https bool, insecure bool, caCert []byte) (*winrm.Endpoint, error) {
 	var host string
 	var port int
 
@@ -33,6 +33,10 @@ func parseEndpoint(addr string) (*winrm.Endpoint, error) {
 	}
 
 	return &winrm.Endpoint{
-		Host: host, Port: port,
+		Host:     host,
+		Port:     port,
+		HTTPS:    https,
+		Insecure: insecure,
+		CACert:   &caCert,
 	}, nil
 }

--- a/winrmcp/endpoint_test.go
+++ b/winrmcp/endpoint_test.go
@@ -1,11 +1,9 @@
 package winrmcp
 
-import (
-	"testing"
-)
+import "testing"
 
 func Test_parsing_an_addr_to_a_winrm_endpoint(t *testing.T) {
-	endpoint, err := parseEndpoint("1.2.3.4:1234")
+	endpoint, err := parseEndpoint("1.2.3.4:1234", false, false, nil)
 
 	if err != nil {
 		t.Fatalf("Should not have been an error: %v", err)
@@ -19,10 +17,17 @@ func Test_parsing_an_addr_to_a_winrm_endpoint(t *testing.T) {
 	if endpoint.Port != 1234 {
 		t.Error("Port should be 1234")
 	}
+	if endpoint.Insecure {
+		t.Error("Endpoint should be insecure")
+	}
+	if endpoint.HTTPS {
+		t.Error("Endpoint should be HTTP not HTTPS")
+	}
 }
 
 func Test_parsing_an_addr_without_a_port_to_a_winrm_endpoint(t *testing.T) {
-	endpoint, err := parseEndpoint("1.2.3.4")
+	certBytes := []byte{1, 2, 3, 4, 5, 6}
+	endpoint, err := parseEndpoint("1.2.3.4", true, true, certBytes)
 
 	if err != nil {
 		t.Fatalf("Should not have been an error: %v", err)
@@ -36,10 +41,25 @@ func Test_parsing_an_addr_without_a_port_to_a_winrm_endpoint(t *testing.T) {
 	if endpoint.Port != 5985 {
 		t.Error("Port should be 5985")
 	}
+	if endpoint.Insecure != true {
+		t.Error("Endpoint should be insecure")
+	}
+	if endpoint.HTTPS != true {
+		t.Error("Endpoint should be HTTPS")
+	}
+
+	if len(*endpoint.CACert) != len(certBytes) {
+		t.Error("Length of CACert is wrong")
+	}
+	for i := 0; i < len(certBytes); i++ {
+		if (*endpoint.CACert)[i] != certBytes[i] {
+			t.Error("CACert is not set correctly")
+		}
+	}
 }
 
 func Test_parsing_an_empty_addr_to_a_winrm_endpoint(t *testing.T) {
-	endpoint, err := parseEndpoint("")
+	endpoint, err := parseEndpoint("", false, false, nil)
 
 	if endpoint != nil {
 		t.Error("Endpoint should be nil")
@@ -50,7 +70,7 @@ func Test_parsing_an_empty_addr_to_a_winrm_endpoint(t *testing.T) {
 }
 
 func Test_parsing_an_addr_with_a_bad_port(t *testing.T) {
-	endpoint, err := parseEndpoint("1.2.3.4:ABCD")
+	endpoint, err := parseEndpoint("1.2.3.4:ABCD", false, false, nil)
 
 	if endpoint != nil {
 		t.Error("Endpoint should be nil")

--- a/winrmcp/winrmcp.go
+++ b/winrmcp/winrmcp.go
@@ -19,6 +19,9 @@ type Winrmcp struct {
 
 type Config struct {
 	Auth                  Auth
+	Https                 bool
+	Insecure              bool
+	CACertBytes           []byte
 	OperationTimeout      time.Duration
 	MaxOperationsPerShell int
 }
@@ -29,7 +32,7 @@ type Auth struct {
 }
 
 func New(addr string, config *Config) (*Winrmcp, error) {
-	endpoint, err := parseEndpoint(addr)
+	endpoint, err := parseEndpoint(addr, config.Https, config.Insecure, config.CACertBytes)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This commit adds support for using HTTPS listeners with winrmcp. It also adds flags to ignore validating the certificate chain, and for providing a custom root CA to validate against.

Note that the default is to use HTTPS rather than HTTP.