### PR TITLE
Parallelise upload to get better upload speeds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 
 cli:
-	@go build -v -o bin/winrmcp
+	@go build -v -o bin/winrmcp.exe
 
 .PHONY: cli

--- a/main.go
+++ b/main.go
@@ -51,7 +51,7 @@ func runMain() error {
 	cacert := flags.String("cacert", "", "ca certificate to validate against")
 	opTimeout := flags.Duration("op-timeout", time.Second*60, "operation timeout")
 	maxOpsPerShell := flags.Int("max-ops-per-shell", 15, "max operations per shell")
-	maxShells := flags.Int("max-shells", 10, "max shells per user")
+	maxShells := flags.Int("max-shells", 5, "max shells per user")
 	flags.Parse(os.Args[1:])
 
 	var certBytes []byte

--- a/main.go
+++ b/main.go
@@ -51,6 +51,7 @@ func runMain() error {
 	cacert := flags.String("cacert", "", "ca certificate to validate against")
 	opTimeout := flags.Duration("op-timeout", time.Second*60, "operation timeout")
 	maxOpsPerShell := flags.Int("max-ops-per-shell", 15, "max operations per shell")
+	maxShells := flags.Int("max-shells", 10, "max shells per user")
 	flags.Parse(os.Args[1:])
 
 	var certBytes []byte
@@ -72,6 +73,7 @@ func runMain() error {
 		CACertBytes:           certBytes,
 		OperationTimeout:      *opTimeout,
 		MaxOperationsPerShell: *maxOpsPerShell,
+		MaxShells:             *maxShells,
 	})
 	if err != nil {
 		return err

--- a/winrmcp/cp.go
+++ b/winrmcp/cp.go
@@ -56,8 +56,8 @@ func uploadContent(client *winrm.Client, maxShell int, maxChunks int, filePath s
 		maxChunks = 1
 	}
 
-	if maxChunks == 0 {
-		maxChunks = 10
+	if maxShell == 0 {
+		maxShell = 5
 	}
 
 	// Create 4 Parallel workers

--- a/winrmcp/winrmcp.go
+++ b/winrmcp/winrmcp.go
@@ -24,6 +24,7 @@ type Config struct {
 	CACertBytes           []byte
 	OperationTimeout      time.Duration
 	MaxOperationsPerShell int
+	MaxShells             int
 }
 
 type Auth struct {

--- a/winrmcp/winrmcp.go
+++ b/winrmcp/winrmcp.go
@@ -64,15 +64,14 @@ func (fs *Winrmcp) Copy(fromPath, toPath string) error {
 
 	if !fi.IsDir() {
 		return fs.Write(toPath, f)
-	} else {
-		fw := fileWalker{
-			client:  fs.client,
-			config:  fs.config,
-			toDir:   toPath,
-			fromDir: fromPath,
-		}
-		return filepath.Walk(fromPath, fw.copyFile)
 	}
+	fw := fileWalker{
+		client:  fs.client,
+		config:  fs.config,
+		toDir:   toPath,
+		fromDir: fromPath,
+	}
+	return filepath.Walk(fromPath, fw.copyFile)
 }
 
 func (fs *Winrmcp) Write(toPath string, src io.Reader) error {


### PR DESCRIPTION
Im trying to get a working parallelised upload mechanism to get better upload speeds.
You get about 5Mbps per worker. 

This will be exposed as an parameter like max chunks, allowing to set according to the destination but 4/10 workers is a safe config and maybe 4 should be the default.

This is still work in progress im putting the PR here to get visibility over the work and maybe some help.

Todo:
- The workers currently write to a file each based on its worker "number" but because they are async the chunks are spread with no specific order, we need to add some functionality that returns the chunk number and use that to re assemble the file. 
  This should be easy by appending the chunk number to the end of the file name chunk that we write on the destination. 
  It would be even easier if we change this code to be more OO instead of plain functions.
