### PR TITLE
check execute error in cleanupContent

### DIFF
--- a/winrmcp/cp.go
+++ b/winrmcp/cp.go
@@ -176,7 +176,10 @@ func cleanupContent(client *winrm.Client, filePath string) error {
 	}
 
 	defer shell.Close()
-	cmd, _ := shell.Execute("powershell", "Remove-Item", filePath, "-ErrorAction SilentlyContinue")
+	cmd, err := shell.Execute("powershell", "Remove-Item", filePath, "-ErrorAction SilentlyContinue")
+	if err != nil {
+		return err
+	}
 
 	cmd.Wait()
 	cmd.Close()


### PR DESCRIPTION
There's an issue open against packer which seems to be a nil pointer exception on this call to `Execute`. 

https://github.com/mitchellh/packer/issues/4390

This PR checks for an error, so we don't panic, and so that we know what went wrong.