### PR TITLE
Support for IPv6 addresses in endpoint address (issue #22)

### DIFF
--- a/winrmcp/endpoint.go
+++ b/winrmcp/endpoint.go
@@ -18,7 +18,7 @@ func parseEndpoint(addr string, https bool, insecure bool, caCert []byte, timeou
 	if addr == "" {
 		return nil, errors.New("Couldn't convert \"\" to an address.")
 	}
-	if !strings.Contains(addr, ":") {
+	if !strings.Contains(addr, ":") || (strings.HasPrefix(addr, "[") && strings.HasSuffix(addr, "]")) {
 		host = addr
 		port = 5985
 	} else {
@@ -26,7 +26,8 @@ func parseEndpoint(addr string, https bool, insecure bool, caCert []byte, timeou
 		if err != nil {
 			return nil, fmt.Errorf("Couldn't convert \"%s\" to an address.", addr)
 		}
-		host = shost
+		// Check for IPv6 addresses and reformat appropriately
+		host = IpFormat(shost)
 		port, err = strconv.Atoi(sport)
 		if err != nil {
 			return nil, errors.New("Couldn't convert \"%s\" to a port number.")
@@ -41,4 +42,16 @@ func parseEndpoint(addr string, https bool, insecure bool, caCert []byte, timeou
 		CACert:   caCert,
 		Timeout:  timeout,
 	}, nil
+}
+
+// IpFormat formats the IP correctly, so we don't provide IPv6 address in an IPv4 format during node communication.
+// We return the ip parameter as is if it's an IPv4 address or a hostname.
+func IpFormat(ip string) string {
+	ipObj := net.ParseIP(ip)
+	// Return the ip/host as is if it's either a hostname or an IPv4 address.
+	if ipObj == nil || ipObj.To4() != nil {
+		return ip
+	}
+
+	return fmt.Sprintf("[%s]", ip)
 }

--- a/winrmcp/endpoint_test.go
+++ b/winrmcp/endpoint_test.go
@@ -65,6 +65,126 @@ func Test_parsing_an_addr_without_a_port_to_a_winrm_endpoint(t *testing.T) {
 	}
 }
 
+func Test_parsing_a_hostname_to_a_winrm_endpoint(t *testing.T) {
+	timeout, _ := time.ParseDuration("1s")
+	endpoint, err := parseEndpoint("windows01:1234", false, false, nil, timeout)
+
+	if err != nil {
+		t.Fatalf("Should not have been an error: %v", err)
+	}
+	if endpoint == nil {
+		t.Error("Endpoint should not be nil")
+	}
+	if endpoint.Host != "windows01" {
+		t.Error("Host should be windows01")
+	}
+	if endpoint.Port != 1234 {
+		t.Error("Port should be 1234")
+	}
+	if endpoint.Insecure {
+		t.Error("Endpoint should be insecure")
+	}
+	if endpoint.HTTPS {
+		t.Error("Endpoint should be HTTP not HTTPS")
+	}
+	if endpoint.Timeout != 1*time.Second {
+		t.Error("Timeout should be 1s")
+	}
+}
+
+func Test_parsing_a_hostname_without_a_port_to_a_winrm_endpoint(t *testing.T) {
+	certBytes := []byte{1, 2, 3, 4, 5, 6}
+	endpoint, err := parseEndpoint("windows01.microsoft.com", true, true, certBytes, 0)
+
+	if err != nil {
+		t.Fatalf("Should not have been an error: %v", err)
+	}
+	if endpoint == nil {
+		t.Error("Endpoint should not be nil")
+	}
+	if endpoint.Host != "windows01.microsoft.com" {
+		t.Error("Host should be windows01.microsoft.com")
+	}
+	if endpoint.Port != 5985 {
+		t.Error("Port should be 5985")
+	}
+	if endpoint.Insecure != true {
+		t.Error("Endpoint should be insecure")
+	}
+	if endpoint.HTTPS != true {
+		t.Error("Endpoint should be HTTPS")
+	}
+
+	if len(endpoint.CACert) != len(certBytes) {
+		t.Error("Length of CACert is wrong")
+	}
+	for i := 0; i < len(certBytes); i++ {
+		if (endpoint.CACert)[i] != certBytes[i] {
+			t.Error("CACert is not set correctly")
+		}
+	}
+}
+
+func Test_parsing_an_ipv6_addr_to_a_winrm_endpoint(t *testing.T) {
+	timeout, _ := time.ParseDuration("1s")
+	endpoint, err := parseEndpoint("[2402:9900:111:1373:ae5:1c:4cb8:dae0]:1234", false, false, nil, timeout)
+
+	if err != nil {
+		t.Fatalf("Should not have been an error: %v", err)
+	}
+	if endpoint == nil {
+		t.Error("Endpoint should not be nil")
+	}
+	if endpoint.Host != "[2402:9900:111:1373:ae5:1c:4cb8:dae0]" {
+		t.Error("Host should be [2402:9900:111:1373:ae5:1c:4cb8:dae0]")
+	}
+	if endpoint.Port != 1234 {
+		t.Error("Port should be 1234")
+	}
+	if endpoint.Insecure {
+		t.Error("Endpoint should be insecure")
+	}
+	if endpoint.HTTPS {
+		t.Error("Endpoint should be HTTP not HTTPS")
+	}
+	if endpoint.Timeout != 1*time.Second {
+		t.Error("Timeout should be 1s")
+	}
+}
+
+func Test_parsing_an_ipv6_addr_without_a_port_to_a_winrm_endpoint(t *testing.T) {
+	certBytes := []byte{1, 2, 3, 4, 5, 6}
+	endpoint, err := parseEndpoint("[2402:9900:111:1373:192a:6b0e:7c46:2563]", true, true, certBytes, 0)
+
+	if err != nil {
+		t.Fatalf("Should not have been an error: %v", err)
+	}
+	if endpoint == nil {
+		t.Error("Endpoint should not be nil")
+	}
+	if endpoint.Host != "[2402:9900:111:1373:192a:6b0e:7c46:2563]" {
+		t.Error("Host should be [2402:9900:111:1373:192a:6b0e:7c46:2563]")
+	}
+	if endpoint.Port != 5985 {
+		t.Error("Port should be 5985")
+	}
+	if endpoint.Insecure != true {
+		t.Error("Endpoint should be insecure")
+	}
+	if endpoint.HTTPS != true {
+		t.Error("Endpoint should be HTTPS")
+	}
+
+	if len(endpoint.CACert) != len(certBytes) {
+		t.Error("Length of CACert is wrong")
+	}
+	for i := 0; i < len(certBytes); i++ {
+		if (endpoint.CACert)[i] != certBytes[i] {
+			t.Error("CACert is not set correctly")
+		}
+	}
+}
+
 func Test_parsing_an_empty_addr_to_a_winrm_endpoint(t *testing.T) {
 	endpoint, err := parseEndpoint("", false, false, nil, 0)
 


### PR DESCRIPTION
Changes to the parse endpoint logic to accept IPv6 address as the hostname of the address and resolve issue #22. Uses IpFormat() function by @kristinn and commited to github.com/hashicorp/terraform to identify valid IPv6 addresses.