### PR TITLE
Add support for TLSServerName

### DIFF
--- a/main.go
+++ b/main.go
@@ -24,6 +24,7 @@ Options:
   -https                  Use HTTPS in preference to HTTP
   -insecure               Do not validate the HTTPS certificate chain
   -cacert                 Filename of CA cert to validate against
+  -tlsservername          Server name to validate against when using https
   -op-timeout=60s         Timeout duration of each WinRM operation
   -max-ops-per-shell=15   Max number of operations per WinRM shell
 
@@ -48,6 +49,7 @@ func runMain() error {
 	pass := flags.String("pass", "", "winrm admin password")
 	https := flags.Bool("https", false, "use https instead of http")
 	insecure := flags.Bool("insecure", false, "do not validate https certificate chain")
+	tlsservername := flags.String("tlsservername", "", "server name to validate against when using https")
 	cacert := flags.String("cacert", "", "ca certificate to validate against")
 	opTimeout := flags.Duration("op-timeout", time.Second*60, "operation timeout")
 	maxOpsPerShell := flags.Int("max-ops-per-shell", 15, "max operations per shell")
@@ -69,6 +71,7 @@ func runMain() error {
 		Auth:                  winrmcp.Auth{User: *user, Password: *pass},
 		Https:                 *https,
 		Insecure:              *insecure,
+		TLSServerName:         *tlsservername,
 		CACertBytes:           certBytes,
 		OperationTimeout:      *opTimeout,
 		MaxOperationsPerShell: *maxOpsPerShell,

--- a/winrmcp/endpoint.go
+++ b/winrmcp/endpoint.go
@@ -11,7 +11,7 @@ import (
 	"github.com/masterzen/winrm"
 )
 
-func parseEndpoint(addr string, https bool, insecure bool, caCert []byte, timeout time.Duration) (*winrm.Endpoint, error) {
+func parseEndpoint(addr string, https bool, insecure bool, tlsServerName string, caCert []byte, timeout time.Duration) (*winrm.Endpoint, error) {
 	var host string
 	var port int
 
@@ -35,12 +35,13 @@ func parseEndpoint(addr string, https bool, insecure bool, caCert []byte, timeou
 	}
 
 	return &winrm.Endpoint{
-		Host:     host,
-		Port:     port,
-		HTTPS:    https,
-		Insecure: insecure,
-		CACert:   caCert,
-		Timeout:  timeout,
+		Host:          host,
+		Port:          port,
+		HTTPS:         https,
+		Insecure:      insecure,
+		TLSServerName: tlsServerName,
+		CACert:        caCert,
+		Timeout:       timeout,
 	}, nil
 }
 

--- a/winrmcp/winrmcp.go
+++ b/winrmcp/winrmcp.go
@@ -20,6 +20,7 @@ type Config struct {
 	Auth                  Auth
 	Https                 bool
 	Insecure              bool
+	TLSServerName         string
 	CACertBytes           []byte
 	ConnectTimeout        time.Duration
 	OperationTimeout      time.Duration
@@ -33,7 +34,7 @@ type Auth struct {
 }
 
 func New(addr string, config *Config) (*Winrmcp, error) {
-	endpoint, err := parseEndpoint(addr, config.Https, config.Insecure, config.CACertBytes, config.ConnectTimeout)
+	endpoint, err := parseEndpoint(addr, config.Https, config.Insecure, config.TLSServerName, config.CACertBytes, config.ConnectTimeout)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Use the winrm TLSServerName configuration option so that the hostname
used when verifying certificates can be explicitly set.