### PR TITLE
checks to ensure file exists

### DIFF
--- a/winrmcp/cp.go
+++ b/winrmcp/cp.go
@@ -176,7 +176,12 @@ func cleanupContent(client *winrm.Client, filePath string) error {
 	}
 
 	defer shell.Close()
-	script := fmt.Sprintf(`Remove-Item %s -ErrorAction SilentlyContinue`, filePath)
+	script := fmt.Sprintf(`
+		$tmp_file_path = [System.IO.Path]::GetFullPath("%s")
+		if (Test-Path $tmp_file_path) {
+			Remove-Item $tmp_file_path -ErrorAction SilentlyContinue
+		}
+	`, filePath)
 
 	cmd, err := shell.Execute(winrm.Powershell(script))
 	if err != nil {


### PR DESCRIPTION
@dylanmei In previous versions of windows or PowerShell `Remove-Item %s -ErrorAction SilentlyContinue` is perfectly fine, I can build Windows Images 2012 R2 with this perfectly fine.

With Windows 2016 this behavior is different. It's now throwing an error and breaking the build.

I created an issue [issues/5752](https://github.com/hashicorp/packer/issues/5752)  And I've confirmed this fix works and no longer breaks Windows 2016 builds.

I have a few lines of the log messages in the issue. I'm happy to supply you with more.
