### PR TITLE
removed unnecessary code.

### DIFF
--- a/winrmcp/cp.go
+++ b/winrmcp/cp.go
@@ -176,12 +176,7 @@ func cleanupContent(client *winrm.Client, filePath string) error {
 	}
 
 	defer shell.Close()
-	script := fmt.Sprintf(`
-		$tmp_file_path = [System.IO.Path]::GetFullPath("%s")
-		if (Test-Path $tmp_file_path) {
-			Remove-Item $tmp_file_path -ErrorAction SilentlyContinue
-		}
-	`, filePath)
+	script := fmt.Sprintf(`&{Remove-Item %s -ErrorAction SilentlyContinue}`, filePath)
 
 	cmd, err := shell.Execute(winrm.Powershell(script))
 	if err != nil {


### PR DESCRIPTION
Removed unnecessary code for a Windows 2016 PowerShell error work around. ([PR 29](https://github.com/packer-community/winrmcp/pull/29))

I was not liking that extra check path, because the check path was unnecessary. I was looking for a simpler way. I found one, It still doesn't explain much to me. It just seems like powershell is being a pain. 

This is the error message I get after editing to the script to log the error message: `errored: unexpected EOF`. This is the bit of code solves the problem, by essentially creating an anonymous function with PS [Script Block](https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_script_blocks?view=powershell-5.1) notation: `&{Remove-Item %s -ErrorAction SilentlyContinue}` And no longer throws unexpected EOF errors. 