### PR TITLE
Fail if path is directory

### DIFF
--- a/winrmcp/cp.go
+++ b/winrmcp/cp.go
@@ -117,7 +117,11 @@ func restoreContent(client *winrm.Client, fromPath, toPath string) error {
 		$tmp_file_path = [System.IO.Path]::GetFullPath("%s")
 		$dest_file_path = [System.IO.Path]::GetFullPath("%s".Trim("'"))
 		if (Test-Path $dest_file_path) {
-			rm $dest_file_path
+			if (Test-Path -Path $dest_file_path -PathType container) {
+				Exit 1
+			} else {
+				rm $dest_file_path
+			}
 		}
 		else {
 			$dest_dir = ([System.IO.Path]::GetDirectoryName($dest_file_path))


### PR DESCRIPTION
Closes #32

Fail in restoreContent() if destination path is a directory.