### PR TITLE
Changed all the Powershell calls to the "echo" cmdlet to use "out-file" with the "-append" option instead

### DIFF
--- a/winrmcp/cp.go
+++ b/winrmcp/cp.go
@@ -144,7 +144,7 @@ func restoreContent(client *winrm.Client, fromPath, toPath string) error {
 				$writer.Close()
 			}
 		} else {
-			echo $null > $dest_file_path
+			out-file -FilePath $dest_file_path -Encoding utf8 -InputObject $null
 		}
 	`, fromPath, toPath)
 
@@ -213,7 +213,7 @@ func cleanupContent(client *winrm.Client, filePath string) error {
 }
 
 func appendContent(shell *winrm.Shell, filePath, content string) error {
-	cmd, err := shell.Execute(fmt.Sprintf("echo %s >> \"%s\"", content, filePath))
+	cmd, err := shell.Execute(fmt.Sprintf("out-file -FilePath \"%s\" -encoding utf8 -Append -InputObject \"%s\"", content, filePath))
 
 	if err != nil {
 		return err


### PR DESCRIPTION
This PR is a preliminary re-implementation of the `appendContent` function which uses `out-file` with the `-append` parameter instead of `echo` w/ a redirect. Using `echo` w/ a redirect will typically result in a unicode-type encoding which uses 16-bit wchar_t internally resulting in twice as much base64 encoded data needing to be decoded. By using `out-file` with a utf8 encoding, this should halve the base64 data that is written to the file which "might" make things a little faster. I think we can use 7-bit ascii due to base64, but to be safe I chose utf8 because it's universal.

However, I believe the same amount of data is being transferred over a socket, but during the decoding process, less data needs to be processed. Also, to execute an i/o redirect the command has to be executed, have its output captured, a handle needs to be created for the file, data needs to be appended (a seek), and then the handle has to be closed. Using `out-file` keeps all functionality within the same implementation and doesn't need to process any of the extra features of `write-output` which supports different logging classes and other special formatting (which can have some implicit performance issues).

This is based on the first suggestion I made in PR #6. It hasn't been tested too well, but should have the exact same semantics as the original implementation. I have not comprehensively measured its performance. :-/